### PR TITLE
Fix amount conversion

### DIFF
--- a/lib/ogone-rails/helpers.rb
+++ b/lib/ogone-rails/helpers.rb
@@ -67,7 +67,7 @@ module OgoneRails
       options.each do |option, value|        
         if options_index.key?(option)
           # ogone param
-          value = (value.to_f * 100).to_i if option == :amount # amount in cents
+          value = (BigDecimal.new(value.to_s) * 100).to_i if option == :amount # amount in cents
           add_ogone_parameter(options_index[option], value)
         else
           # custom param

--- a/test/test_ogone-rails.rb
+++ b/test/test_ogone-rails.rb
@@ -5,4 +5,9 @@ class TestOgoneRails < Test::Unit::TestCase
   should "probably rename this file and start testing for real" do
     flunk "hey buddy, you should probably rename this file and start testing for real"
   end
+
+  should "set amount correctly" do
+    @ogone_fields = OgoneRails::Helpers.ogone_fields(amount: 586.8)
+    assert_includes(@ogone_fields, "<input type='hidden' name='amount' value='58680' />")
+  end
 end


### PR DESCRIPTION
We should not be relying on floats for currency calculations and use decimal type instead.

For example using `586.80` as an amount, we get `58679` in cents using float conversion. Whereas we get the correct value of `58680` using the `BigDecimal` type.