### PR TITLE
Add UTF-8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Define ogone parameters in a yaml config file:
   			currency: "EUR"
   			language: "nl_NL"
   			mode: 'test'
+  			encoding: 'ISO-8859-1'
   		production:
   			pspid: "hoetmaaiers"
   			sha_in: "0123456789abcdefghijklmnopqrstuv"
@@ -31,6 +32,7 @@ Define ogone parameters in a yaml config file:
   			currency: "EUR"
   			language: "nl_NL"
   			mode: 'live'
+  			encoding: 'ISO-8859-1'
 
 __Deprecated in version >= 0.1.3__, configure ogone-rails in an initializer:
 

--- a/lib/generators/ogone/templates/ogone.yml
+++ b/lib/generators/ogone/templates/ogone.yml
@@ -5,7 +5,8 @@ development:
   currency: "EUR"
   language: "nl_NL"
   mode: 'test'
-  
+  encoding: 'ISO-8859-1'
+
 test:
   pspid: "example"
   sha_in: "0123456789abcdefghijklmnopqrstuv"
@@ -13,7 +14,8 @@ test:
   currency: "EUR"
   language: "nl_NL"
   mode: 'test'
-  
+  encoding: 'ISO-8859-1'
+
 production:
   pspid: "example"
   sha_in: "0123456789abcdefghijklmnopqrstuv"
@@ -21,3 +23,4 @@ production:
   currency: "EUR"
   language: "nl_NL"
   mode: 'live'
+  encoding: 'ISO-8859-1'

--- a/lib/ogone-rails/config.rb
+++ b/lib/ogone-rails/config.rb
@@ -2,8 +2,12 @@
 module OgoneRails
   extend self
   
-  TEST_SERVICE_URL = 'https://secure.ogone.com/ncol/test/orderstandard.asp'
-  LIVE_SERVICE_URL = 'https://secure.ogone.com/ncol/prod/orderstandard.asp'  
+  TEST_SERVICE_URL_ISO = 'https://secure.ogone.com/ncol/test/orderstandard.asp'
+  TEST_SERVICE_URL_UTF8 = 'https://secure.ogone.com/ncol/test/orderstandard_utf8.asp'
+
+  LIVE_SERVICE_URL_ISO = 'https://secure.ogone.com/ncol/prod/orderstandard.asp'
+  LIVE_SERVICE_URL_UTF8 = 'https://secure.ogone.com/ncol/prod/orderstandard_utf8.asp'
+
   STATUS_CODES = {
     0   => "Incomplete or invalid",
     1	  => "Cancelled by client",
@@ -50,10 +54,10 @@ module OgoneRails
   @sha_out  = nil
   @currency = "EUR"
   @language = "nl_NL"
-  @mode    = "live"
-  
+  @mode     = "live"
+  @encoding = "ISO-8859-1" # Default to ISO for backwards compatibility
+
   def config c
-    
     c.each do |key, value|
       case key
       when :pspid
@@ -68,6 +72,8 @@ module OgoneRails
         @language = value unless value.nil?
       when :mode
         @mode = value unless value.nil?
+      when :encoding
+        @encoding = value unless value.nil?
       end
     end
   end
@@ -96,4 +102,9 @@ module OgoneRails
   def self.mode
     @mode
   end
+
+  def self.encoding
+    @encoding.upcase
+  end
+
 end

--- a/lib/ogone-rails/helpers.rb
+++ b/lib/ogone-rails/helpers.rb
@@ -8,21 +8,19 @@ module OgoneRails
     @form
      
     def ogone_form_tag options={}
-      OgoneRails::mode == "live" ? action = OgoneRails::LIVE_SERVICE_URL : action = OgoneRails::TEST_SERVICE_URL
-      
+
       @form = Form.new
       
       form_content = yield(form_content)
       
-      output = @form.get_form_tag(action, options)
+      output = @form.get_form_tag(get_service_url, options)
       output << form_content
       output << "\n</form>"#.html_safe
       
       # block.methods
       output.html_safe
     end
-    
-    
+
     def ogone_fields options = {}
       @form = Form.new
       @hash = StringToHash.new
@@ -103,6 +101,15 @@ module OgoneRails
           @hash.add_parameter(name.to_s, value)
         end
       end
+
+      def get_service_url
+        if OgoneRails::mode == "live"
+          OgoneRails::encoding == "UTF-8" ? OgoneRails::LIVE_SERVICE_URL_UTF8 : OgoneRails::LIVE_SERVICE_URL_ISO
+        else
+          OgoneRails::encoding == "UTF-8" ? OgoneRails::TEST_SERVICE_URL_UTF8 : OgoneRails::TEST_SERVICE_URL_ISO
+        end
+      end
+
   end
 end
 


### PR DESCRIPTION
If your Ogone account is configured to use UTF-8 you should use the utf-8 service url instead of the regular one.

eg: 
ISO = https://secure.ogone.com/ncol/test/orderstandard.asp
UTF8 = https://secure.ogone.com/ncol/test/orderstandard_utf8.asp

I've added a 'encoding' variable to the config file, so everyone can configure it the way they want.
For backward compatibility the default is set to 'ISO-8859-1' and can be overridden with 'UTF-8'.

Any encoding setting will be converted to uppercase for maximum flexibility.
